### PR TITLE
Add new cobra commands with cobra add

### DIFF
--- a/cmd/create.go
+++ b/cmd/create.go
@@ -1,22 +1,18 @@
 package cmd
 
 import (
-	"io"
-
 	"github.com/spf13/cobra"
 )
 
-func NewCmdCreate(out io.Writer) *cobra.Command {
+var createCmd = &cobra.Command{
+	Use:   "create ",
+	Short: "Create a resource in github",
+	Run: func(cmd *cobra.Command, args []string) {
+		cmd.Help()
+	},
+}
 
-	cmd := &cobra.Command{
-		Use:   "create ",
-		Short: "Create a resource in github",
-		Run: func(cmd *cobra.Command, args []string) {
-			cmd.Help()
-		},
-	}
-
-	// create subcommands
-	cmd.AddCommand(NewCmdCreateRepo(out))
-	return cmd
+func init() {
+	RootCmd.AddCommand(createCmd)
+	createCmd.AddCommand(createRepoCmd)
 }

--- a/cmd/create_repo.go
+++ b/cmd/create_repo.go
@@ -38,7 +38,8 @@ func RunCreateRepo(cmd *cobra.Command, args []string, out io.Writer, c *CreateRe
 	}
 	repoName := args[0]
 
-	client := rootCommand.gclient.GetClient()
+	// client := rootCommand.gclient.GetClient()
+	client := gc.GetClient()
 	repo := &github.Repository{
 		Name:    github.String(repoName),
 		Private: github.Bool(false),

--- a/cmd/create_repo.go
+++ b/cmd/create_repo.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"io"
 	"strings"
 
 	"github.com/google/go-github/github"
@@ -14,25 +13,20 @@ type CreateRepoOptions struct {
 	IsPrivate string
 }
 
-func NewCmdCreateRepo(out io.Writer) *cobra.Command {
-	options := &CreateRepoOptions{}
-
-	cmd := &cobra.Command{
-		Use:   "repo [name]",
-		Short: "Create repo",
-		Long:  `Creates a Github repo.`,
-		Run: func(cmd *cobra.Command, args []string) {
-			err := RunCreateRepo(cmd, args, out, options)
-			if err != nil {
-				exitWithError(err)
-			}
-		},
-	}
-
-	return cmd
+var createRepoOptions = &CreateRepoOptions{}
+var createRepoCmd = &cobra.Command{
+	Use:   "repo [name]",
+	Short: "Create repo",
+	Long:  `Creates a Github repo.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		err := RunCreateRepo(cmd, args, createRepoOptions)
+		if err != nil {
+			exitWithError(err)
+		}
+	},
 }
 
-func RunCreateRepo(cmd *cobra.Command, args []string, out io.Writer, c *CreateRepoOptions) error {
+func RunCreateRepo(cmd *cobra.Command, args []string, c *CreateRepoOptions) error {
 	if len(args) != 1 {
 		return cmd.Help()
 	}

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -1,22 +1,18 @@
 package cmd
 
 import (
-	"io"
-
 	"github.com/spf13/cobra"
 )
 
-func NewCmdDelete(out io.Writer) *cobra.Command {
+var deleteCmd = &cobra.Command{
+	Use:   "delete ",
+	Short: "Delete a resource in github",
+	Run: func(cmd *cobra.Command, args []string) {
+		cmd.Help()
+	},
+}
 
-	cmd := &cobra.Command{
-		Use:   "delete ",
-		Short: "Delete a resource in github",
-		Run: func(cmd *cobra.Command, args []string) {
-			cmd.Help()
-		},
-	}
-
-	// create subcommands
-	cmd.AddCommand(NewCmdDeleteRepo(out))
-	return cmd
+func init() {
+	RootCmd.AddCommand(deleteCmd)
+	deleteCmd.AddCommand(deleteRepoCmd)
 }

--- a/cmd/delete_repo.go
+++ b/cmd/delete_repo.go
@@ -37,8 +37,10 @@ func RunDeleteRepo(cmd *cobra.Command, args []string, out io.Writer, o *DeleteRe
 		return cmd.Help()
 	}
 	repoName := args[0]
-	client := rootCommand.gclient.GetClient()
-	user := rootCommand.gclient.User
+	// client := rootCommand.gclient.GetClient()
+	client := gc.GetClient()
+	// user := rootCommand.gclient.User
+	user := gc.User
 	repoUrl := user + "/" + repoName
 	c := utils.AskForConfirmation("Are you sure you want to delete " + repoUrl + " ?")
 	if c {

--- a/cmd/delete_repo.go
+++ b/cmd/delete_repo.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"io"
 	"strings"
 
 	"github.com/alok87/github-cli/pkg/utils"
@@ -14,32 +13,25 @@ type DeleteRepoOptions struct {
 	IsPrivate string
 }
 
-func NewCmdDeleteRepo(out io.Writer) *cobra.Command {
-	options := &DeleteRepoOptions{}
-
-	cmd := &cobra.Command{
-		Use:   "repo [name]",
-		Short: "Delete repo",
-		Long:  `Deletes a Github repo.`,
-		Run: func(cmd *cobra.Command, args []string) {
-			err := RunDeleteRepo(cmd, args, out, options)
-			if err != nil {
-				exitWithError(err)
-			}
-		},
-	}
-
-	return cmd
+var deleteRepoOptions = &DeleteRepoOptions{}
+var deleteRepoCmd = &cobra.Command{
+	Use:   "repo [name]",
+	Short: "Delete repo",
+	Long:  `Deletes a Github repo.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		err := RunDeleteRepo(cmd, args, deleteRepoOptions)
+		if err != nil {
+			exitWithError(err)
+		}
+	},
 }
 
-func RunDeleteRepo(cmd *cobra.Command, args []string, out io.Writer, o *DeleteRepoOptions) error {
+func RunDeleteRepo(cmd *cobra.Command, args []string, o *DeleteRepoOptions) error {
 	if len(args) != 1 {
 		return cmd.Help()
 	}
 	repoName := args[0]
-	// client := rootCommand.gclient.GetClient()
 	client := gc.GetClient()
-	// user := rootCommand.gclient.User
 	user := gc.User
 	repoUrl := user + "/" + repoName
 	c := utils.AskForConfirmation("Are you sure you want to delete " + repoUrl + " ?")

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -1,22 +1,18 @@
 package cmd
 
 import (
-	"io"
-
 	"github.com/spf13/cobra"
 )
 
-func NewCmdGet(out io.Writer) *cobra.Command {
+var getCmd = &cobra.Command{
+	Use:   "get ",
+	Short: "Get resource(s) from github",
+	Run: func(cmd *cobra.Command, args []string) {
+		cmd.Help()
+	},
+}
 
-	cmd := &cobra.Command{
-		Use:   "get ",
-		Short: "Get resource(s) from github",
-		Run: func(cmd *cobra.Command, args []string) {
-			cmd.Help()
-		},
-	}
-
-	// create subcommands
-	cmd.AddCommand(NewCmdGetRepos(out))
-	return cmd
+func init() {
+	RootCmd.AddCommand(getCmd)
+	getCmd.AddCommand(getReposCmd)
 }

--- a/cmd/get_repos.go
+++ b/cmd/get_repos.go
@@ -71,10 +71,12 @@ var newRepo = func(r *github.Repository) Repo {
 
 // getRepos fetches and returns all the repos of the logged in user.
 var getRepos = func() ([]*github.Repository, error) {
-	client := rootCommand.gclient.GetClient()
+	// client := rootCommand.gclient.GetClient()
+	client := gc.GetClient()
 	// User should be fetched only after the above client init, else user remains
 	// empty.
-	user := rootCommand.gclient.User
+	// user := rootCommand.gclient.User
+	user := gc.User
 	opt := &github.RepositoryListOptions{
 		Type: "all", Sort: "updated",
 		ListOptions: github.ListOptions{PerPage: reposPerPage}}

--- a/cmd/get_repos.go
+++ b/cmd/get_repos.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"io"
 	"os"
 	"strconv"
 
@@ -36,26 +35,22 @@ func (r Repo) RepoString() []string {
 		strconv.Itoa(r.Stars), strconv.Itoa(r.Forks)}
 }
 
-func NewCmdGetRepos(out io.Writer) *cobra.Command {
-	options := &GetRepoOptions{}
+var getRepoOptions = &GetRepoOptions{}
+var getReposCmd = &cobra.Command{
+	Use:   "repos",
+	Short: "Get repo",
+	Long:  `Gets the list of Github repos for the logged user`,
+	Run: func(cmd *cobra.Command, args []string) {
+		err := RunGetRepos(cmd, args, getRepoOptions)
+		if err != nil {
+			exitWithError(err)
+		}
+	},
+}
 
-	cmd := &cobra.Command{
-		Use:   "repos",
-		Short: "Get repo",
-		Long:  `Gets the list of Github repos for the logged user`,
-		Run: func(cmd *cobra.Command, args []string) {
-			err := RunGetRepos(cmd, args, out, options)
-			if err != nil {
-				exitWithError(err)
-			}
-		},
-	}
-
-	// `limit` flag, with default 10, to fetch limited number of repos at a time.
-	cmd.Flags().IntVarP(&reposPerPage, "limit", "l",
+func init() {
+	getReposCmd.Flags().IntVarP(&reposPerPage, "limit", "l",
 		defaultReposPerPage, "number of repos to fetch")
-
-	return cmd
 }
 
 // newRepo creates a new Repo object, given a github repository.
@@ -71,11 +66,7 @@ var newRepo = func(r *github.Repository) Repo {
 
 // getRepos fetches and returns all the repos of the logged in user.
 var getRepos = func() ([]*github.Repository, error) {
-	// client := rootCommand.gclient.GetClient()
 	client := gc.GetClient()
-	// User should be fetched only after the above client init, else user remains
-	// empty.
-	// user := rootCommand.gclient.User
 	user := gc.User
 	opt := &github.RepositoryListOptions{
 		Type: "all", Sort: "updated",
@@ -106,7 +97,7 @@ var renderTable = func(repos []*github.Repository) {
 	table.Render()
 }
 
-func RunGetRepos(cmd *cobra.Command, args []string, out io.Writer, c *GetRepoOptions) error {
+func RunGetRepos(cmd *cobra.Command, args []string, c *GetRepoOptions) error {
 	if len(args) > 0 {
 		return cmd.Help()
 	}

--- a/cmd/get_repos_test.go
+++ b/cmd/get_repos_test.go
@@ -22,7 +22,7 @@ func getFakeRepo(url string, lang string, stars int, forks int) github.Repositor
 		StargazersCount: starsPtr, ForksCount: forksPtr}
 }
 
-func TestRepo(t *testing.T) {
+func TestGetRepos(t *testing.T) {
 	cases := []struct {
 		url   string
 		lang  string

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"io"
 	"io/ioutil"
 	"os"
 	"path"
@@ -12,23 +11,22 @@ import (
 	"github.com/spf13/viper"
 )
 
-func NewCmdLogin(out io.Writer) *cobra.Command {
-
-	cmd := &cobra.Command{
-		Use:   "login [oauth-token]",
-		Short: "Setup login for accessing Github",
-		Run: func(cmd *cobra.Command, args []string) {
-			err := RunLogin(cmd, args, out)
-			if err != nil {
-				exitWithError(err)
-			}
-		},
-	}
-
-	return cmd
+var loginCmd = &cobra.Command{
+	Use:   "login [oauth-token]",
+	Short: "Setup login for accessing Github",
+	Run: func(cmd *cobra.Command, args []string) {
+		err := RunLogin(cmd, args)
+		if err != nil {
+			exitWithError(err)
+		}
+	},
 }
 
-func RunLogin(cmd *cobra.Command, args []string, out io.Writer) error {
+func init() {
+	RootCmd.AddCommand(loginCmd)
+}
+
+func RunLogin(cmd *cobra.Command, args []string) error {
 	if len(args) != 1 {
 		return cmd.Help()
 	}
@@ -75,7 +73,6 @@ func RunLogin(cmd *cobra.Command, args []string, out io.Writer) error {
 		}
 		configYaml = []byte(output)
 	}
-	// err := rootCommand.gclient.CheckConnection(gitOauth)
 	err := gc.CheckConnection(gitOauth)
 	if err != nil {
 		if madeConfigFile {

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -75,7 +75,8 @@ func RunLogin(cmd *cobra.Command, args []string, out io.Writer) error {
 		}
 		configYaml = []byte(output)
 	}
-	err := rootCommand.gclient.CheckConnection(gitOauth)
+	// err := rootCommand.gclient.CheckConnection(gitOauth)
+	err := gc.CheckConnection(gitOauth)
 	if err != nil {
 		if madeConfigFile {
 			err_del := os.Remove(configFile)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	goflag "flag"
 	"fmt"
-	"io"
 	"os"
 
 	"github.com/alok87/github-cli/pkg/ghub"
@@ -11,45 +10,19 @@ import (
 	"github.com/spf13/viper"
 )
 
-type RootCmd struct {
-	configFile   string
-	cobraCommand *cobra.Command
-	gclient      *ghub.Gclient
-}
-
 var gc = &ghub.Gclient{Name: "Github Client"}
 var configFile string
 
-var rootCommand = RootCmd{
-	cobraCommand: &cobra.Command{
-		Use:   "github-cli",
-		Short: "Use github-cli to perform github tasks.",
-		Long:  "Use github-cli to perform github tasks.",
-	},
-	gclient: &ghub.Gclient{
-		Name: "Github Client",
-	},
+var RootCmd = &cobra.Command{
+	Use:   "github-cli",
+	Short: "Use github-cli to perform github tasks.",
+	Long:  "Use github-cli to perform github tasks.",
 }
 
 func init() {
 	cobra.OnInitialize(initConfig)
-	NewCmdRoot(os.Stdout)
-}
-
-func NewCmdRoot(out io.Writer) *cobra.Command {
-	//options := &RootOptions{}
-	cmd := rootCommand.cobraCommand
-
-	cmd.PersistentFlags().AddGoFlagSet(goflag.CommandLine)
-	cmd.PersistentFlags().StringVar(&configFile, "config", "", "config file (default is $HOME/.github-cli.yaml)")
-
-	// create subcommands
-	cmd.AddCommand(NewCmdLogin(out))
-	cmd.AddCommand(NewCmdGet(out))
-	cmd.AddCommand(NewCmdCreate(out))
-	cmd.AddCommand(NewCmdDelete(out))
-
-	return cmd
+	RootCmd.PersistentFlags().AddGoFlagSet(goflag.CommandLine)
+	RootCmd.PersistentFlags().StringVar(&configFile, "config", "", "config file (default is $HOME/.github-cli.yaml)")
 }
 
 // initConfig reads in config file and ENV variables if set.
@@ -76,14 +49,10 @@ func initConfig() {
 	}
 }
 
-func (c *RootCmd) AddCommand(cmd *cobra.Command) {
-	c.cobraCommand.AddCommand(cmd)
-}
-
 func Execute() {
 	goflag.Set("logtostderr", "true")
 	goflag.CommandLine.Parse([]string{})
-	if err := rootCommand.cobraCommand.Execute(); err != nil {
+	if err := RootCmd.Execute(); err != nil {
 		exitWithError(err)
 	}
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -17,6 +17,9 @@ type RootCmd struct {
 	gclient      *ghub.Gclient
 }
 
+var gc = &ghub.Gclient{Name: "Github Client"}
+var configFile string
+
 var rootCommand = RootCmd{
 	cobraCommand: &cobra.Command{
 		Use:   "github-cli",
@@ -38,7 +41,7 @@ func NewCmdRoot(out io.Writer) *cobra.Command {
 	cmd := rootCommand.cobraCommand
 
 	cmd.PersistentFlags().AddGoFlagSet(goflag.CommandLine)
-	cmd.PersistentFlags().StringVar(&rootCommand.configFile, "config", "", "config file (default is $HOME/.github-cli.yaml)")
+	cmd.PersistentFlags().StringVar(&configFile, "config", "", "config file (default is $HOME/.github-cli.yaml)")
 
 	// create subcommands
 	cmd.AddCommand(NewCmdLogin(out))
@@ -51,9 +54,9 @@ func NewCmdRoot(out io.Writer) *cobra.Command {
 
 // initConfig reads in config file and ENV variables if set.
 func initConfig() {
-	if rootCommand.configFile != "" {
+	if configFile != "" {
 		// enable ability to specify config file via flag
-		viper.SetConfigFile(rootCommand.configFile)
+		viper.SetConfigFile(configFile)
 	}
 
 	viper.SetConfigName(".github-cli") // name of config file (without extension)

--- a/pkg/ghub/client.go
+++ b/pkg/ghub/client.go
@@ -61,9 +61,7 @@ func (c *Gclient) GetClient() *github.Client {
 }
 
 func (c *Gclient) SetUser() string {
-	fmt.Println("Setting User!!!")
 	currentUser, _, _ := c.client.Users.Get("")
-	fmt.Println(*currentUser.Login)
 	c.User = *currentUser.Login
 	return c.User
 }

--- a/pkg/ghub/client.go
+++ b/pkg/ghub/client.go
@@ -61,7 +61,9 @@ func (c *Gclient) GetClient() *github.Client {
 }
 
 func (c *Gclient) SetUser() string {
+	fmt.Println("Setting User!!!")
 	currentUser, _, _ := c.client.Users.Get("")
+	fmt.Println(*currentUser.Login)
 	c.User = *currentUser.Login
 	return c.User
 }


### PR DESCRIPTION
Removes wrapper around `cobra.Command` and enables easy addition of new commands with `cobra add`.
Fix for #3 plan 2.