### PR TITLE
Create repo add remote

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -38,6 +38,12 @@
   version = "v1.0"
 
 [[projects]]
+  branch = "master"
+  name = "github.com/jbenet/go-context"
+  packages = ["io"]
+  revision = "d14ea06fba99483203c19d92cfcd13ebe73135f4"
+
+[[projects]]
   name = "github.com/magiconair/properties"
   packages = ["."]
   revision = "be5ece7dd465ab0765a9682137865547526d1dfb"
@@ -81,6 +87,12 @@
 
 [[projects]]
   branch = "master"
+  name = "github.com/sergi/go-diff"
+  packages = ["diffmatchpatch"]
+  revision = "2fc9cd33b5f86077aa3e0f442fa0476a9fa9a1dc"
+
+[[projects]]
+  branch = "master"
   name = "github.com/spf13/afero"
   packages = [".","mem"]
   revision = "5660eeed305fe5f69c8fc6cf899132a459a97064"
@@ -116,6 +128,24 @@
   version = "v1.0.0"
 
 [[projects]]
+  name = "github.com/src-d/gcfg"
+  packages = [".","scanner","token","types"]
+  revision = "f187355171c936ac84a82793659ebb4936bc1c23"
+  version = "v1.3.0"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/xanzy/ssh-agent"
+  packages = ["."]
+  revision = "ba9c9e33906f58169366275e3450db66139a31a9"
+
+[[projects]]
+  branch = "master"
+  name = "golang.org/x/crypto"
+  packages = ["curve25519","ed25519","ed25519/internal/edwards25519","ssh","ssh/agent","ssh/knownhosts"]
+  revision = "687d4b818545e443c8ba223cbef20b1721afd4db"
+
+[[projects]]
   branch = "master"
   name = "golang.org/x/net"
   packages = ["context","context/ctxhttp"]
@@ -146,6 +176,24 @@
   version = "v1.0.0"
 
 [[projects]]
+  name = "gopkg.in/src-d/go-billy.v3"
+  packages = [".","helper/chroot","helper/polyfill","osfs","util"]
+  revision = "c329b7bc7b9d24905d2bc1b85bfa29f7ae266314"
+  version = "v3.1.0"
+
+[[projects]]
+  name = "gopkg.in/src-d/go-git.v4"
+  packages = [".","config","internal/revision","plumbing","plumbing/cache","plumbing/filemode","plumbing/format/config","plumbing/format/diff","plumbing/format/gitignore","plumbing/format/idxfile","plumbing/format/index","plumbing/format/objfile","plumbing/format/packfile","plumbing/format/pktline","plumbing/object","plumbing/protocol/packp","plumbing/protocol/packp/capability","plumbing/protocol/packp/sideband","plumbing/revlist","plumbing/storer","plumbing/transport","plumbing/transport/client","plumbing/transport/file","plumbing/transport/git","plumbing/transport/http","plumbing/transport/internal/common","plumbing/transport/server","plumbing/transport/ssh","storage","storage/filesystem","storage/filesystem/internal/dotgit","storage/memory","utils/binary","utils/diff","utils/ioutil","utils/merkletrie","utils/merkletrie/filesystem","utils/merkletrie/index","utils/merkletrie/internal/frame","utils/merkletrie/noder"]
+  revision = "f9879dd043f84936a1f8acb8a53b74332a7ae135"
+  version = "v4.0.0-rc15"
+
+[[projects]]
+  name = "gopkg.in/warnings.v0"
+  packages = ["."]
+  revision = "8a331561fe74dadba6edfc59f3be66c22c3b065d"
+  version = "v0.1.1"
+
+[[projects]]
   branch = "v2"
   name = "gopkg.in/yaml.v2"
   packages = ["."]
@@ -154,6 +202,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "d41d4f72dd0ee5c444daa57d1d89678d668334fe8978b35d645f024ec002cfee"
+  inputs-digest = "8695594fc4b1a3e0915637739c82d24653ca442d40c469d7c3d025949340e8c3"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -25,3 +25,7 @@
 [[constraint]]
   version = "0.8.0"
   name = "github.com/pkg/errors"
+
+[[constraint]]
+  branch = "v4"
+  name = "gopkg.in/src-d/go-git.v4"

--- a/Makefile
+++ b/Makefile
@@ -23,17 +23,17 @@ fmt: ## Run go fmt ./...
 	fi
 
 vet: ## Apply go vet to all the Go files.
-	@if [ "`go vet $(PKGS) | tee /dev/stderr`"]; then \
+	@if [ "`go vet $(PKGS) | tee /dev/stderr`" ]; then \
 		echo "^ go ver errors!" && echo && exit 1; \
 	fi
 
 megacheck: install-tools ## Apply megacheck to all the Go files.
-	@if [ "`megacheck $(PKGS) | tee /dev/stderr`"]; then \
+	@if [ "`megacheck $(PKGS) | tee /dev/stderr`" ]; then \
 		echo "^ megacheck errors!" && echo && exit 1; \
 	fi
 
 lint: install-tools ## Check for style mistakes in all the Go files using golint.
-	@if [ "`golint $(PKGS) | tee /dev/stderr`"]; then \
+	@if [ "`golint $(PKGS) | tee /dev/stderr`" ]; then \
 		echo "^ golint errors!" && echo && exit 1; \
 	fi
 

--- a/cmd/create_repo_test.go
+++ b/cmd/create_repo_test.go
@@ -1,0 +1,69 @@
+package cmd
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	git "gopkg.in/src-d/go-git.v4"
+)
+
+func TestAddRemote(t *testing.T) {
+	testCases := []struct {
+		name         string
+		isGitRepo    bool
+		remoteExists bool
+		wantErr      error
+	}{
+		{
+			name:      "not a git repo",
+			isGitRepo: false,
+			wantErr:   errAddRemoteNoRepo,
+		},
+		{
+			name:      "a git repo",
+			isGitRepo: true,
+			wantErr:   nil,
+		},
+		{
+			name:         "remote already exists",
+			isGitRepo:    true,
+			remoteExists: true,
+			wantErr:      errAddRemoteExists,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			repoName := "some-repo-name"
+			username := "userxyz"
+
+			// Create a tempdir
+			tempdir, err := ioutil.TempDir("", "github-cli-test")
+			if err != nil {
+				t.Fatal("failed to create temporary directory")
+			}
+
+			if tc.isGitRepo {
+				// Initialize a git repo.
+				_, err := git.PlainInit(tempdir, false)
+				if err != nil {
+					t.Fatal("failed to initialize git repo")
+				}
+
+				// Add a remote.
+				if tc.remoteExists {
+					addRemote(username, tempdir, repoName)
+				}
+			}
+
+			err = addRemote(username, tempdir, repoName)
+			if err != tc.wantErr {
+				t.Fatalf("unexpected error: \n\t(GOT): %v\n\t(WNT): %v", err, tc.wantErr)
+			}
+
+			// Cleanup the test assets.
+			os.RemoveAll(tempdir)
+		})
+	}
+}

--- a/pkg/ghub/client.go
+++ b/pkg/ghub/client.go
@@ -15,9 +15,12 @@ import (
 
 // Gclient is ghub client struct.
 type Gclient struct {
-	Name   string
+	// Name of the client.
+	Name string
+	// Github username.
+	User string
+
 	client *github.Client
-	User   string
 }
 
 // ConfigName is the configuration file name.


### PR DESCRIPTION
This change adds `--remote` flag to `create repo`, which adds remote to
the repo at the current working directory's repo, associated with the newly
created repo.

Also, adds a new dependency `gopkg.in/src-d/go-git.v4` for performing all
the git operations.

Usage:
```
$ git init
<--- do some work locally --->

$ github-cli create repo myrepo --remote
Repo myrepo created in github.
Added remote "origin".

$ git remote -v
origin	https://github.com/darkowlzz/myrepo (fetch)
origin	https://github.com/darkowlzz/myrepo (push)
```