### PR TITLE
Add `open repo` command to open the repo in web browser.

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -80,6 +80,12 @@
   version = "v1.0.1"
 
 [[projects]]
+  branch = "master"
+  name = "github.com/pkg/browser"
+  packages = ["."]
+  revision = "c90ca0c84f15f81c982e32665bffd8d7aac8f097"
+
+[[projects]]
   name = "github.com/pkg/errors"
   packages = ["."]
   revision = "645ef00459ed84a119197bfb8d8205042c6df63d"
@@ -202,6 +208,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "8695594fc4b1a3e0915637739c82d24653ca442d40c469d7c3d025949340e8c3"
+  inputs-digest = "75ad7ba9de64ebe6eb85d6aa5db75941f988b987f86217205645626337aa05a0"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -29,3 +29,7 @@
 [[constraint]]
   branch = "v4"
   name = "gopkg.in/src-d/go-git.v4"
+
+[[constraint]]
+  branch = "master"
+  name = "github.com/pkg/browser"

--- a/cmd/open.go
+++ b/cmd/open.go
@@ -1,0 +1,19 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// openCmd represents the open command
+var openCmd = &cobra.Command{
+	Use:   "open",
+	Short: "Open a github resource in web browser",
+	Run: func(cmd *cobra.Command, args []string) {
+		cmd.Help()
+	},
+}
+
+func init() {
+	RootCmd.AddCommand(openCmd)
+	openCmd.AddCommand(openRepoCmd)
+}

--- a/cmd/open_repo.go
+++ b/cmd/open_repo.go
@@ -1,0 +1,44 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path"
+	"path/filepath"
+
+	"github.com/pkg/browser"
+	"github.com/spf13/cobra"
+)
+
+// openRepoCmd represents the openRepo command
+var openRepoCmd = &cobra.Command{
+	Use:   "repo",
+	Short: "Open Github repo under the logged in user in a web browser",
+	Long: `Opens Github repo page in a web browser. The repo url is derived
+from the logged in username. Hence, a url would be of the form
+
+	github.com/username/reponame
+	`,
+	Run: func(cmd *cobra.Command, args []string) {
+		// Get the project name from the directory name.
+		cwd, err := os.Getwd()
+		if err != nil {
+			exitWithError(err)
+		}
+		projectName := filepath.Base(cwd)
+
+		// Initialize the gc client to have Github account details.
+		ctx := context.Background()
+		_, err = gc.GetClient(ctx)
+		if err != nil {
+			exitWithError(err)
+		}
+
+		url := "https://" + path.Join("github.com", gc.User, projectName)
+		fmt.Printf("Opening %s in web browser...\n", url)
+		if err = browser.OpenURL(url); err != nil {
+			exitWithError(err)
+		}
+	},
+}


### PR DESCRIPTION
This change introduces `open repo` command to open the current repo in a
web browser. The repo URL is derived from the currently logged-in user.
Since we don't store any repo data anywhere, we don't have any information
about the github repo upstream at the moment.